### PR TITLE
Optional tags

### DIFF
--- a/sitemap.xsl
+++ b/sitemap.xsl
@@ -149,11 +149,20 @@
                                     <xsl:apply-templates select="video:*" />
                                 </td>
                                 <xsl:apply-templates select="sitemap:changefreq" />
+                                <xsl:if test="not(sitemap:changefreq)">
+                                    <td class="pa3 tr bb b--silver"></td>
+                                </xsl:if>
                                 <xsl:apply-templates select="sitemap:priority" />
+                                <xsl:if test="not(sitemap:priority)">
+                                    <td class="pa3 tr bb b--silver"></td>
+                                </xsl:if>
                                 <xsl:if test="sitemap:lastmod">
                                     <td class="pa3 tr bb b--silver">
                                         <xsl:value-of select="concat(substring(sitemap:lastmod, 0, 11), concat(' ', substring(sitemap:lastmod, 12, 5)), concat(' ', substring(sitemap:lastmod, 20, 6)))" />
                                     </td>
+                                </xsl:if>
+                                <xsl:if test="not(sitemap:lastmod)">
+                                    <td class="pa3 tr bb b--silver"></td>
                                 </xsl:if>
                             </tr>
                         </xsl:for-each>


### PR DESCRIPTION
The following tags are optional(https://www.sitemaps.org/protocol.html): lastmod, changefreq, priority.
If they are missing, the columns are shifted.
These changes correct this issue.